### PR TITLE
Proposal - allow to omit 'roles' in annotation

### DIFF
--- a/Annotation/Secure.php
+++ b/Annotation/Secure.php
@@ -1,13 +1,19 @@
 <?php
 namespace Lsw\SecureControllerBundle\Annotation;
 
-use Doctrine\Common\Annotations\Annotation;
-
 /**
  * @Annotation
  */
-class Secure extends Annotation
+class Secure
 {
     public $roles = "";
-     
+
+    public function __construct(array $values)
+    {
+        if (isset($values['value'])) {
+            $values['roles'] = $values['value'];
+        }
+
+        $this->roles = $values['roles'];
+    }
 }


### PR DESCRIPTION
This change allows very simple migration from JMS to your bundle - only need to replace

```
-use JMS\SecurityExtraBundle\Annotation\Secure;
+use Lsw\SecureControllerBundle\Annotation\Secure;
```

and don't need to replace 

```
-     * @Secure("ROLE_VIEW")
+     * @Secure(roles="ROLE_VIEW")
```

in each action method
