### PR TITLE
Added quotes to the arguments of secure_controller.controller_listener

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,6 +4,6 @@ parameters:
 services:
     secure_controller.controller_listener:
         class: %secure_controller.controller_listener.class%
-        arguments: [@annotation_reader,@security.context]
+        arguments: [ "@annotation_reader", "@security.context" ]
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }


### PR DESCRIPTION
This avoids warnings of this bundle in Symfony 2.8.

cc/ @GregoireHebert and @mevdschee

Closes #9